### PR TITLE
Change metadata to appear as karma-preprocessor

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "url": "git+https://github.com/blgm/karma-buble-preprocessor.git"
   },
   "keywords": [
-    "karma",
+    "karma-preprocessor",
     "buble",
-    "preprocessor",
     "ES2015"
   ],
   "author": "George Blue",


### PR DESCRIPTION
The Karma help page uses the query https://www.npmjs.com/browse/keyword/karma-preprocessor to list npm modules that are Karma preprocessors.  Currently this does not list karma-buble-preprocessor because the metadata in `package.json` has `karma` and `preprocessor` listed separately, not conjoined.