### PR TITLE
test: add node 16 and drop node 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10', '12', '14' ]
+        node: [ '12', '14', '16' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Node 16 is the active LTS
- Node 10 has been out of support for a long time and dependencies
  (e.g. Jest) no longer work with it