### PR TITLE
test: remove Node.js 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '12', '14', '16', '18' ]
+        node: [ '14', '16', '18' ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node.js 12 is out of security support, and dependencies (jest) have dropped support, so it makes sense to stop testing with it.